### PR TITLE
fix variable bounds not being set in use-data but outside

### DIFF
--- a/src/components/data/use-data.tsx
+++ b/src/components/data/use-data.tsx
@@ -97,6 +97,10 @@ export function useCatalogData() {
   const { setQueryKeys, setQueryStatus, checkQueryStatusPresent } =
     useAppStateStore((state) => state.appInterfaceActions.queryActions);
 
+  const setColorFormatting = useProjectStore(
+    (state) => state.dataSourceActions.setColorFormatting,
+  );
+
   useEffect(() => {
     if (dataSources) {
       const queryKeys = [
@@ -213,6 +217,55 @@ export function useCatalogData() {
     () => aggregateData(queries.results, queryKeys),
     [queries],
   );
+
+  useEffect(() => {
+    if (data.allIDs) {
+      data.allIDs.forEach((dataSourceID) => {
+        if (data.byID[dataSourceID].bounds && dataSources.byID[dataSourceID]) {
+          ["twoD", "threeD", "plot"].forEach((type) => {
+            const formattingType = type as "twoD" | "threeD" | "plot";
+
+            const boundsFromData = {} as {
+              [variable: string]: [number, number] | null;
+            };
+
+            dataSources.byID[dataSourceID].metadata.variables.required_vars
+              .concat(
+                dataSources.byID[dataSourceID].metadata.variables.datetime_vars,
+              )
+              .concat(
+                dataSources.byID[dataSourceID].metadata.variables.added_vars,
+              )
+              .concat(["t"])
+              .forEach((variable) => {
+                return (boundsFromData[variable] = dataSources.byID[
+                  dataSourceID
+                ].formatting[formattingType].color.linear.domain[
+                  dataSources.byID[dataSourceID].formatting[formattingType]
+                    .color.linear.variable
+                ]
+                  ? dataSources.byID[dataSourceID].formatting[formattingType]
+                      .color.linear.domain[
+                      dataSources.byID[dataSourceID].formatting[formattingType]
+                        .color.linear.variable
+                    ]
+                  : data.byID[dataSourceID].bounds[variable]);
+              });
+
+            setColorFormatting(dataSourceID, formattingType, {
+              ...dataSources.byID[dataSourceID].formatting[formattingType]
+                .color,
+              linear: {
+                ...dataSources.byID[dataSourceID].formatting[formattingType]
+                  .color.linear,
+                domain: boundsFromData,
+              },
+            });
+          });
+        }
+      });
+    }
+  }, [data.allIDs]);
 
   return { data: data } as DataCacheResult;
 }

--- a/src/components/data/variables/variable-form.tsx
+++ b/src/components/data/variables/variable-form.tsx
@@ -244,56 +244,6 @@ export default function DataSourceVariableForm({
     (state) => state.metadataActions.clearAllVariableMaps,
   );
 
-  const setColorFormatting = useProjectStore(
-    (state) => state.dataSourceActions.setColorFormatting,
-  );
-
-  const { data } = useCatalogData();
-
-  const { dataSources } = useProjectStore((state) => state);
-
-  useEffect(() => {
-    if (data.allIDs) {
-      data.allIDs.forEach((dataSourceID) => {
-        if (data.byID[dataSourceID].bounds && dataSources.byID[dataSourceID]) {
-          ["twoD", "threeD", "plot"].forEach((type) => {
-            const formattingType = type as "twoD" | "threeD" | "plot";
-
-            const boundsFromData = {} as {
-              [variable: string]: [number, number] | null;
-            };
-
-            dataSource.metadata.variables.required_vars
-              .concat(dataSource.metadata.variables.datetime_vars)
-              .concat(dataSource.metadata.variables.added_vars)
-              .concat(["t"])
-              .forEach((variable) => {
-                return (boundsFromData[variable] = dataSource.formatting[
-                  formattingType
-                ].color.linear.domain[
-                  dataSource.formatting[formattingType].color.linear.variable
-                ]
-                  ? dataSource.formatting[formattingType].color.linear.domain[
-                      dataSource.formatting[formattingType].color.linear
-                        .variable
-                    ]
-                  : data.byID[dataSourceID].bounds[variable]);
-              });
-
-            setColorFormatting(dataSourceID, formattingType, {
-              ...dataSources.byID[dataSourceID].formatting[formattingType]
-                .color,
-              linear: {
-                ...dataSources.byID[dataSourceID].formatting[formattingType]
-                  .color.linear,
-                domain: boundsFromData,
-              },
-            });
-          });
-        }
-      });
-    }
-  }, [data.allIDs]);
 
   return (
     <Box sx={{ p: 2 }}>

--- a/src/components/map/use-layers.tsx
+++ b/src/components/map/use-layers.tsx
@@ -31,6 +31,12 @@ export function useStemPlotLayers(
       if (scaleX && scaleY) {
         return data.allIDs.map((dataSourceID) => {
           if (data.byID[dataSourceID]) {
+            console.log(dataSources.byID[dataSourceID].formatting.plot.color.linear
+                  .domain[
+                  dataSources.byID[dataSourceID].formatting.plot.color.linear
+                    .variable
+                ]!)
+
             const linearColorScale = d3
               .scaleSequential(
                 d3.piecewise(


### PR DESCRIPTION
Breaking async loading

Explicitly set layer IDs by pathname so the Deck.gl layers are updated for the two timeline plots